### PR TITLE
Resolve crash if globals not defined in config

### DIFF
--- a/lib/guard/jshintrb.rb
+++ b/lib/guard/jshintrb.rb
@@ -15,7 +15,7 @@ module Guard
       }.merge(options)
 
       @jshint_options = JSON.load(File.read('.jshintrc'))
-      @jshint_globals = @jshint_options.delete('globals')
+      @jshint_globals = @jshint_options.delete('globals') { Hash.new }
       @jshint_ignored = File.read('.jshintignore').split.collect { |pattern| Dir.glob(pattern) }.flatten
 
       @failed_paths = []


### PR DESCRIPTION
This just returns an empty hash if the 'globals' key isn't present in the jshint_options hash.